### PR TITLE
DCC v2 update

### DIFF
--- a/R/DccMetadata.R
+++ b/R/DccMetadata.R
@@ -27,18 +27,11 @@
                                NA_character_,
                                NA_character_,
                                NA_character_,
-                               NA_character_,
-                               NA_character_,
-                               NA_character_,
-                               NA_character_,
-                               NA_character_,
                                NA_character_),
-                           minVersion = numeric_version(c(rep("0.01", 13L))),
+                           minVersion = numeric_version(c(rep("0.01", 8L))),
                            row.names =
-                             c("SeqSetId", "tamperedIni", "trimGaloreOpts", "flash2Opts",
-                               "umiExtractOpts", "bowtie2Opts", "umiDedupOpts",
-                               "Raw", "Trimmed", "Stitched", "Aligned", "umiQ30",
-                               "rtsQ30"),
+                             c("SeqSetId", "tamperedIni", "Raw", "Trimmed", 
+                               "Stitched", "Aligned", "umiQ30", "rtsQ30"),
                            stringsAsFactors = FALSE),
               "Code_Summary" =
                 data.frame(labelDescription =

--- a/R/readDccFile.R
+++ b/R/readDccFile.R
@@ -3,6 +3,15 @@ function(file)
 {
   # Read data from Reporter Code Count (RCC) file
   lines <- trimws(readLines(file))
+  
+  if(lines[3] == "SoftwareVersion,\"GeoMx_NGS_Pipeline_ 2.0.0\""){
+    lines[3] <- "SoftwareVersion,0.02"
+  }else{
+    # removing unused dnd program lines
+    trimGalore <- grep("trimGalore", lines)
+    Raw <- grep("Raw", lines)
+    lines <- lines[-c(trimGalore:(Raw - 1))]
+  }
 
   # Split data by tags
   tags <- names(.dccMetadata[["schema"]])
@@ -44,8 +53,8 @@ function(file)
 
   # Extract FileVersion for internal checks
   fileVersion <- output[["Header"]][1L, "FileVersion"]
-  if (!(numeric_version(fileVersion) %in% numeric_version(c("0.01"))))
-    stop("\"FileVersion\" in Header section must be 0.01")
+  if (!(numeric_version(fileVersion) %in% numeric_version(c("0.01", "0.02"))))
+    stop("\"FileVersion\" in Header section must be 0.01 or 0.02")
 
   # Check single row attributes
   for (section in c("Header", "Scan_Attributes", "NGS_Processing_Attributes")) {
@@ -61,7 +70,7 @@ function(file)
   # Coerce numeric data in Lane Attributes
   cols <- c( "Raw", "Trimmed", "Stitched", "Aligned", "umiQ30", "rtsQ30" )
   output[["NGS_Processing_Attributes"]][, cols] <-
-    lapply(output[["NGS_Processing_Attributes"]][, cols], as.integer)
+    lapply(output[["NGS_Processing_Attributes"]][, cols], as.numeric)
 
   # Coerce the column name ID to be SampleID
   names(output[["Scan_Attributes"]])[names(output[["Scan_Attributes"]]) == "ID"] <- "SampleID"

--- a/R/readNanoStringGeoMxSet.R
+++ b/R/readNanoStringGeoMxSet.R
@@ -74,6 +74,11 @@ function(dccFiles,
     data.frame(data[[x]][["Code_Summary"]],
                Sample_ID = names(data)[x]))
   probeAssay <- do.call(rbind, probeAssay)
+  zeroProbes <- setdiff(rownames(pkcData), unique(probeAssay[["RTS_ID"]]))
+  zeroProbeAssay <- data.frame(RTS_ID=pkcData[zeroProbes, "RTS_ID"], 
+    Count=rep(0, length(zeroProbes)),
+    Sample_ID=rep(probeAssay[1, "Sample_ID"], length(zeroProbes)))
+  probeAssay <- rbind(probeAssay, zeroProbeAssay)
   probeAssay[["Module"]] <- pkcData[probeAssay[["RTS_ID"]], "Module"]
   probeAssay <- reshape2::dcast(probeAssay, RTS_ID + Module ~ Sample_ID, 
       value.var="Count", fill=0)

--- a/R/readPKCFile.R
+++ b/R/readPKCFile.R
@@ -13,7 +13,7 @@ function(file)
   # NEO Not used currently, need to merge with above call and function
   #target_notes <- generate_pkc_targ_notes(pkc_json_list, rtsid_lookup_df)
   # create negative column 
-  rtsid_lookup_df$Negative <- grepl("Negative", rtsid_lookup_df$Codeclass)
+  rtsid_lookup_df$Negative <- grepl("Negative", rtsid_lookup_df$CodeClass)
   rtsid_lookup_df$RTS_ID <- gsub("RNA", "RTS00", rtsid_lookup_df[["RTS_ID"]])
   # Coerce output to DataFrame
   rtsid_lookup_df <- S4Vectors::DataFrame(rtsid_lookup_df)
@@ -37,7 +37,8 @@ generate_pkc_lookup <- function(jsons_vec) {
   lookup_df <- data.frame(RTS_ID=character(), 
                           Target=character(), 
                           Module=character(), 
-                          Codeclass=character(),
+                          CodeClass=character(), 
+                          ProbeID=character(),
                           stringsAsFactors=FALSE)
   for (curr_idx in seq_len(length(jsons_vec))) {
     curr_module <- names(jsons_vec)[curr_idx]
@@ -47,8 +48,9 @@ generate_pkc_lookup <- function(jsons_vec) {
       curr_code_class <- targ[["CodeClass"]]
       for (prb in targ[["Probes"]]) {
         curr_RTS_ID <- prb$RTS_ID
+        curr_probe_ID <- prb$ProbeID
         lookup_df[nrow(lookup_df) + 1, ] <- 
-          list(curr_RTS_ID, curr_targ, curr_module, curr_code_class)
+          list(curr_RTS_ID, curr_targ, curr_module, curr_code_class, curr_probe_ID)
       }
     }
   }
@@ -64,7 +66,7 @@ generate_pkc_targ_notes <- function(jsons_vec, lookup_tab) {
                HUGOSymbol=sub_lookup[["Target"]],
                TargetGroup=rep("All Probes", length(rownames(sub_lookup))),
                AnalyteType=rep("RNA", nrow(sub_lookup)),
-               Codeclass=sub_lookup[, "Codeclass"],
+               Codeclass=sub_lookup[, "CodeClass"],
                Pooling=sub_lookup[, "Module"],
                stringsAsFactors=FALSE)
   for (curr_idx in seq_len(length(jsons_vec))) {

--- a/R/readPKCFile.R
+++ b/R/readPKCFile.R
@@ -14,7 +14,7 @@ function(file)
   #target_notes <- generate_pkc_targ_notes(pkc_json_list, rtsid_lookup_df)
   # create negative column 
   rtsid_lookup_df$Negative <- grepl("Negative", rtsid_lookup_df$Codeclass)
-  rtsid_lookup_df$RTS_ID <- gsub("RTS00", "RNA", rtsid_lookup_df[["RTS_ID"]])
+  rtsid_lookup_df$RTS_ID <- gsub("RNA", "RTS00", rtsid_lookup_df[["RTS_ID"]])
   # Coerce output to DataFrame
   rtsid_lookup_df <- S4Vectors::DataFrame(rtsid_lookup_df)
   

--- a/R/readPKCFile.R
+++ b/R/readPKCFile.R
@@ -64,7 +64,7 @@ generate_pkc_targ_notes <- function(jsons_vec, lookup_tab) {
                HUGOSymbol=sub_lookup[["Target"]],
                TargetGroup=rep("All Probes", length(rownames(sub_lookup))),
                AnalyteType=rep("RNA", nrow(sub_lookup)),
-               Codeclass=sub_lookup[, "CodeClass"],
+               CodeClass=sub_lookup[, "CodeClass"],
                Pooling=sub_lookup[, "Module"],
                stringsAsFactors=FALSE)
   for (curr_idx in seq_len(length(jsons_vec))) {


### PR DESCRIPTION
Closes #34 and closes #28

- removed unused options from NGS_Processing_Attributes since V2 DCC files do not have these: "trimGaloreOpts", "flash2Opts", "umiExtractOpts", "bowtie2Opts", "umiDedupOpts".

- SoftwareVersion == 0.02 is now a valid option.

- changed NGS_Processing_Attributes to numerics rather than integers since Q30 metrics are percentages. 

- Updates codeclass capitalization

- Includes all possible probes in pkc