### PR TITLE
Allow optional parameters for read_xlsx

### DIFF
--- a/R/readNanoStringGeoMxSet.R
+++ b/R/readNanoStringGeoMxSet.R
@@ -6,7 +6,8 @@ function(dccFiles,
          phenoDataDccColName = "Sample_ID",
          phenoDataColPrefix = "",
          protocolDataColNames = NULL,
-         experimentDataColNames = NULL)
+         experimentDataColNames = NULL,
+         ...)
 {
   # check inputs
   if (!(sum(grepl("\\.dcc$",dccFiles)) == length(dccFiles) && length(dccFiles) > 0L)){
@@ -27,7 +28,7 @@ function(dccFiles,
   if (is.null(phenoDataFile)) {
     stop("Please specify an input for phenoDataFile.")
   } else {
-    pheno <- readxl::read_xlsx(phenoDataFile, col_names = TRUE, sheet = phenoDataSheet)
+    pheno <- readxl::read_xlsx(phenoDataFile, col_names = TRUE, sheet = phenoDataSheet, ...)
     pheno <- data.frame(pheno, stringsAsFactors = FALSE, check.names = FALSE)
     j <- colnames(pheno)[colnames(pheno) == phenoDataDccColName]
     if (length(j) == 0L){

--- a/man/readNanoStringGeoMxSet.Rd
+++ b/man/readNanoStringGeoMxSet.Rd
@@ -31,7 +31,7 @@ readNanoStringGeoMxSet(dccFiles, pkcFiles, phenoDataFile,
     featureData columns, and protocolData columns.}
   \item{protocolDataColNames}{Character list of column names from \code{phenoDataFile} containing data about the experimental protocol or sequencing data.}
   \item{experimentDataColNames}{Character list of column names from \code{phenoDataFile} containing data about the experiment's meta-data.}
-  \item{...}{optional parameters to pass to \code{readxl::read_xlsx} function for annotation read in}
+  \item{...}{Optional parameters to pass to \code{readxl::read_xlsx} function for annotation read in}
 }
 
 \value{

--- a/man/readNanoStringGeoMxSet.Rd
+++ b/man/readNanoStringGeoMxSet.Rd
@@ -13,7 +13,7 @@
 readNanoStringGeoMxSet(dccFiles, pkcFiles, phenoDataFile, 
                      phenoDataSheet, phenoDataDccColName = "Sample_ID",
                      phenoDataColPrefix = "", protocolDataColNames = NULL,
-                     experimentDataColNames = NULL)
+                     experimentDataColNames = NULL, ...)
 }
 
 \arguments{
@@ -31,6 +31,7 @@ readNanoStringGeoMxSet(dccFiles, pkcFiles, phenoDataFile,
     featureData columns, and protocolData columns.}
   \item{protocolDataColNames}{Character list of column names from \code{phenoDataFile} containing data about the experimental protocol or sequencing data.}
   \item{experimentDataColNames}{Character list of column names from \code{phenoDataFile} containing data about the experiment's meta-data.}
+  \item{...}{optional parameters to pass to \code{readxl::read_xlsx} function for annotation read in}
 }
 
 \value{

--- a/tests/testthat/test_readGeoMxSet.R
+++ b/tests/testthat/test_readGeoMxSet.R
@@ -115,4 +115,46 @@ testthat::test_that("test that the counts of testData@assayData$exprs match thos
   expect_true(correct)
 })
 
+n_aois <- 15
+
+testData <-
+  suppressWarnings(readNanoStringGeoMxSet(dccFiles = DCCFiles, 
+                                          pkcFiles = PKCFiles,
+                                          phenoDataFile = SampleAnnotationFile,
+                                          phenoDataSheet = "CW005",
+                                          phenoDataDccColName = "Sample_ID",
+                                          protocolDataColNames = c("aoi",
+                                                                   "cell_line",
+                                                                   "roi_rep",
+                                                                   "pool_rep",
+                                                                   "slide_rep"),
+                                          experimentDataColNames = c("panel"),
+                                          col_types = c(rep("text", 4), "numeric", rep("text", 2),
+                                                        "numeric", rep("text", 4)),
+                                          n_max = n_aois + 1))
+
+# req 7: test that ... gets translated to read_xlsx():------
+testthat::test_that("test that ... gets translated to read_xlsx()", {
+  expect_true(dim(testData)[2] == n_aois) 
+  expect_true(class(pData(testData)$roi) == "numeric")
+  expect_true(class(pData(testData)$area) == "numeric")
+})
+
+# req 7: test that only valid ... gets translated to read_xlsx():------
+testthat::test_that("test that only valid ... gets translated to read_xlsx()", {
+  expect_error(testData <-
+                 suppressWarnings(readNanoStringGeoMxSet(dccFiles = DCCFiles, 
+                                                         pkcFiles = PKCFiles,
+                                                         phenoDataFile = SampleAnnotationFile,
+                                                         phenoDataSheet = "CW005",
+                                                         phenoDataDccColName = "Sample_ID",
+                                                         protocolDataColNames = c("aoi",
+                                                                                  "cell_line",
+                                                                                  "roi_rep",
+                                                                                  "pool_rep",
+                                                                                  "slide_rep"),
+                                                         experimentDataColNames = c("panel"),
+                                                         trim_ws = c(rep("text", 4), "numeric", rep("text", 2),
+                                                                       "numeric", rep("text", 4)))))
+})
 


### PR DESCRIPTION
Allows user to pass optional parameters to read_xlsx for greater control over annotation file read in.

Resolves #111 