### PR TITLE
Update write for newest DCC versions

### DIFF
--- a/R/writeNanoStringGeoMxSet.R
+++ b/R/writeNanoStringGeoMxSet.R
@@ -1,13 +1,14 @@
 writeNanoStringGeoMxSet <- function(x, dir = getwd()) {
   stopifnot(is(x, "NanoStringGeoMxSet"))
+  if (featureType(x) == "Target") {
+    stop("featureType must be 'Probe'")
+  }
   if (!dir.exists(dir)) 
     dir.create(dir)
   features <- pData(featureData(x))[, c("RTS_ID")]
   header <- "<Header>\nFileVersion,%s\nSoftwareVersion,%s\nDate,%s\n</Header>\n"
   scanAttr <- paste0("<Scan_Attributes>\nID,%s\nPlate_ID,%s\nWell,%s\n</Scan_Attributes>\n")
-  laneAttr <- paste0("<NGS_Processing_Attributes>\nSeqSetId,%s\ntamperedIni,%s\ntrimGaloreOpts,%s\n", 
-                     "flash2Opts,%s\numiExtractOpts,%s\nbowtie2Opts,%s\n", 
-                     "umiDedupOpts,%s\nRaw,%d\nTrimmed,%d\n", 
+  laneAttr <- paste0("<NGS_Processing_Attributes>\nSeqSetId,%s\nRaw,%d\nTrimmed,%d\n", 
                      "Stitched,%d\nAligned,%d\numiQ30,%.4f\n", 
                      "rtsQ30,%.4f\n</NGS_Processing_Attributes>\n")
   for (i in seq_len(dim(x)[["Samples"]])) {
@@ -23,10 +24,7 @@ writeNanoStringGeoMxSet <- function(x, dir = getwd()) {
     writeLines(sprintf(scanAttr, protocolRow[["SampleID"]], protocolRow[["Plate_ID"]], 
                        protocolRow[["Well"]]), con)
 
-    writeLines(sprintf(laneAttr, protocolRow[["SeqSetId"]], protocolRow[["tamperedIni"]], 
-                       protocolRow[["trimGaloreOpts"]], protocolRow[["flash2Opts"]], 
-                       protocolRow[["umiExtractOpts"]], protocolRow[["bowtie2Opts"]], 
-                       protocolRow[["umiDedupOpts"]], protocolRow[["Raw"]],
+    writeLines(sprintf(laneAttr, protocolRow[["SeqSetId"]], protocolRow[["Raw"]],
                        protocolRow[["Trimmed"]], protocolRow[["Stitched"]], 
                        protocolRow[["Aligned"]], protocolRow[["umiQ30"]],
                        protocolRow[["rtsQ30"]]), 
@@ -35,8 +33,7 @@ writeNanoStringGeoMxSet <- function(x, dir = getwd()) {
     write.table(cbind(features[which(exprs(x)[, i]>0)], 
                       Count = exprs(x)[which(exprs(x)[, i]>0), i]), file = con, quote = FALSE, 
                 sep = ",", row.names = FALSE, col.names = FALSE)
-    writeLines("</Code_Summary>\n", con)
-    writeLines("SOMEHASH100000000000", con)
+    writeLines("</Code_Summary>", con)
     close(con)
   }
   invisible(file.path(dir, sampleNames(x)))

--- a/tests/testthat/test_writeNanoStringGeoMxSet.R
+++ b/tests/testthat/test_writeNanoStringGeoMxSet.R
@@ -1,0 +1,100 @@
+### CONFIGURATION SECTION ###
+library(GeomxTools)
+library(testthat)
+
+datadir <- system.file("extdata", "DSP_NGS_Example_Data",
+                       package="GeomxTools")
+DCCFiles <- dir(datadir, pattern=".dcc$", full.names=TRUE)
+PKCFiles <- unzip(zipfile = file.path(datadir,  "/pkcs.zip"))
+SampleAnnotationFile <- file.path(datadir, "annotations.xlsx")
+
+demoData <-
+  suppressWarnings(readNanoStringGeoMxSet(dccFiles = DCCFiles, 
+                                          pkcFiles = PKCFiles,
+                                          phenoDataFile = SampleAnnotationFile,
+                                          phenoDataSheet = "CW005",
+                                          phenoDataDccColName = "Sample_ID",
+                                          protocolDataColNames = c("aoi",
+                                                                   "cell_line",
+                                                                   "roi_rep",
+                                                                   "pool_rep",
+                                                                   "slide_rep"),
+                                          experimentDataColNames = c("panel")))
+
+
+
+writeDir <-  "writeTest/"
+if(dir.exists(writeDir)){
+  unlink(writeDir, recursive = TRUE, force = TRUE)
+}
+
+NTCs <- unique(demoData@protocolData@data$NTC_ID)
+writtenDCCs <- basename(DCCFiles)
+writtenDCCs <- writtenDCCs[!writtenDCCs %in% NTCs]
+
+writeNanoStringGeoMxSet(demoData, dir = writeDir)
+
+# req 1: test DCC files are written after read in
+testthat::test_that("test DCC files are written after read in", {
+  expect_true(dir.exists(writeDir))
+  expect_true(all(dir(writeDir) %in% writtenDCCs))
+  expect_true(all(writtenDCCs %in% dir(writeDir)))
+})
+
+unlink(writeDir, recursive = TRUE, force = TRUE)
+
+#Shift counts to one to mimic how DSPDA handles zero counts
+demoData <- shiftCountsOne(demoData, elt="exprs", useDALogic=TRUE) 
+writeNanoStringGeoMxSet(demoData, dir = writeDir)
+
+# req 2: test DCC files are written after shifting counts by one
+testthat::test_that("test DCC files are written after shifting counts by one", {
+  expect_true(dir.exists(writeDir))
+  expect_true(all(dir(writeDir) %in% writtenDCCs))
+  expect_true(all(writtenDCCs %in% dir(writeDir)))
+})
+unlink(writeDir, recursive = TRUE, force = TRUE)
+
+#QC flags
+demoData <- setSegmentQCFlags(demoData)
+writeNanoStringGeoMxSet(demoData, dir = writeDir)
+
+# req 3: test DCC files are written after SegmentQC
+testthat::test_that("test DCC files are written after SegmentQC", {
+  expect_true(dir.exists(writeDir))
+  expect_true(all(dir(writeDir) %in% writtenDCCs))
+  expect_true(all(writtenDCCs %in% dir(writeDir)))
+})
+unlink(writeDir, recursive = TRUE, force = TRUE)
+
+demoData <- setBioProbeQCFlags(demoData)
+writeNanoStringGeoMxSet(demoData, dir = writeDir)
+
+# req 3: test DCC files are written after Probe QC
+testthat::test_that("test DCC files are written after Probe QC", {
+  expect_true(dir.exists(writeDir))
+  expect_true(all(dir(writeDir) %in% writtenDCCs))
+  expect_true(all(writtenDCCs %in% dir(writeDir)))
+})
+unlink(writeDir, recursive = TRUE, force = TRUE)
+
+#aggregate counts
+demoData <- aggregateCounts(demoData)
+
+
+# req 4: test error occurs when writing set after aggregating counts
+testthat::test_that("test error occurs when writing set after aggregating counts", {
+  expect_error(writeNanoStringGeoMxSet(demoData, dir = writeDir))
+})
+unlink(writeDir, recursive = TRUE, force = TRUE)
+
+#normalize
+demoData <- normalize(demoData , data_type="RNA", norm_method="quant",
+                      desiredQuantile = .9, toElt = "q_norm")
+
+# req 4: test error occurs when writing set after aggregating counts
+testthat::test_that("test error occurs when writing set after manipulating target level counts", {
+  expect_error(writeNanoStringGeoMxSet(demoData, dir = writeDir))
+})
+unlink(writeDir, recursive = TRUE, force = TRUE)
+


### PR DESCRIPTION
Updated function to match current versions of inputs
Added error handling for target-level object (only probe data can be reverted back to DCC)

Resolves #114 