### PR TITLE
Allow for rerunning of summarize negs

### DIFF
--- a/R/NanoStringGeoMxSet-aggregate.R
+++ b/R/NanoStringGeoMxSet-aggregate.R
@@ -118,6 +118,8 @@ summarizeNegatives <-
         summaryDF <- do.call(cbind, summaryList)
         colnames(summaryDF) <- summaryListNames
         summaryDF <- summaryDF[sampleNames(object), ]
+        pData(object) <- pData(object)[, 
+                             !colnames(pData(object)) %in% summaryListNames]
         pData(object) <- cbind(pData(object), summaryDF)
         return(object)
 }


### PR DESCRIPTION
User can run summarize negs multiple times
Old values with the same calculation will be recalculated and replaced

Resolves #108 