### PR TITLE
Bioc3.19 small bug fixes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: GeomxTools
 Title: NanoString GeoMx Tools
 Description: Tools for NanoString Technologies GeoMx Technology.  Package provides functions for reading in DCC and
          PKC files based on an ExpressionSet derived object.  Normalization and QC functions are also included.
-Version: 3.7.2
+Version: 3.7.3
 Encoding: UTF-8
 Authors@R: c(person("Maddy", "Griswold", email = "mgriswold@nanostring.com", role = c("cre", "aut")),
 	     person("Nicole", "Ortogero", email = "nortogero@nanostring.com", role = c("aut")), 
@@ -47,5 +47,5 @@ biocViews: GeneExpression, Transcription, CellBasedAssays, DataImport,
            Normalization, Spatial
 VignetteEngine: knitr::rmarkdown
 VignetteBuilder: knitr
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.1
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# GeomxTools 3.7.3
+* small bug fix in version comparisons (PKC & Seurat)
+* update SpatialExperiment vignette plot coordinates
+
 # GeomxTools 3.7.2
 * Seurat v5 coercion
 * IPA data loading

--- a/R/coercions.R
+++ b/R/coercions.R
@@ -80,14 +80,15 @@ as.Seurat.NanoStringGeoMxSet <- function(x, ident = NULL, normData = NULL,
     
     QCMetrics <- "QCFlags"
     
-    meta <- as.data.frame(as.data.table(sData(x)[,!colnames(sData(x)) %in%  c(sequencingMetrics, QCMetrics)]))
+    meta <- as.data.frame(as.data.table(sData(x)[,!colnames(sData(x)) %in%  
+                                                   c(sequencingMetrics, QCMetrics)]))
     
     if(any(grepl("_", rownames(x)))){
       rownames(x) <- gsub("_", "-", rownames(x))
       message("Feature names cannot have underscores ('_'), replacing with dashes ('-')")
     }
     
-    if(packageVersion("Seurat") < 5){
+    if(packageVersion("Seurat") < "5.0.0"){
       seuratConvert <- suppressWarnings(Seurat::CreateSeuratObject(counts = assayDataElement(x, normData), 
                                                                    assay = "GeoMx", 
                                                                    project = expinfo(experimentData(x))[["title"]]))

--- a/R/readPKCFile.R
+++ b/R/readPKCFile.R
@@ -28,8 +28,8 @@ function(file, default_pkc_vers=NULL)
   } else {
     use_pkc_names <- lapply(multi_mods, function(mod) {
         mod_idx <- header[["PKCModule"]] == mod
-        max_vers <- as.numeric(as.character(max(as.numeric_version(
-          header[["PKCFileVersion"]][mod_idx]))))
+        max_vers <- as.numeric(as.character(max(as.numeric_version(as.character(
+          header[["PKCFileVersion"]][mod_idx])))))
         max_name <- names(header[["PKCFileVersion"]][
           header[["PKCFileVersion"]] == max_vers])
         return(max_name)

--- a/vignettes/GeomxSet_coercions.Rmd
+++ b/vignettes/GeomxSet_coercions.Rmd
@@ -349,20 +349,21 @@ When coercing, we can add the coordinate columns and they will be appended to th
 
 ```{r SpatialExperiment coercion}
 
-nsclcSPE <- as.SpatialExperiment(nsclc, normData = "exprs_norm", coordinates = c("x", "y"))
+nsclcSPE <- as.SpatialExperiment(nsclc, normData = "exprs_norm", 
+                                 coordinates = c("x", "y"))
 
 nsclcSPE
 
 data.frame(head(spatialCoords(nsclcSPE)))
 ```
 
-With the coordinates and the metadata, we can create spatial graphing figures similar to Seurat's
+With the coordinates and the metadata, we can create spatial graphing figures similar to Seurat's. To get the same orientation as Seurat we must swap the axes and flip the y. 
 ```{r graphing with SPE}
 figureData <- as.data.frame(cbind(colData(nsclcSPE), spatialCoords(nsclcSPE)))
 
 figureData <- cbind(figureData, A2M=as.numeric(nsclcSPE@assays@data$GeoMx["A2M",]))
 
-tumor <- ggplot(figureData[figureData$AOI.name == "Tumor",], aes(x=x, y=y, color = A2M))+
+tumor <- ggplot(figureData[figureData$AOI.name == "Tumor",], aes(x=y, y=-x, color = A2M))+
   geom_point(size = 6)+
   scale_color_continuous(type = "viridis",
                         limits = c(min(figureData$A2M), 
@@ -374,7 +375,7 @@ tumor <- ggplot(figureData[figureData$AOI.name == "Tumor",], aes(x=x, y=y, color
   labs(title = "Tumor")
 
 
-TME <- ggplot(figureData[figureData$AOI.name == "TME",], aes(x=x, y=y, color = A2M))+
+TME <- ggplot(figureData[figureData$AOI.name == "TME",], aes(x=y, y=-x, color = A2M))+
   geom_point(size = 6)+
   scale_color_continuous(type = "viridis",
                         limits = c(min(figureData$A2M), 

--- a/vignettes/GeomxSet_coercions.Rmd
+++ b/vignettes/GeomxSet_coercions.Rmd
@@ -127,7 +127,7 @@ as.Seurat(norm_target_demoData, normData = "exprs_norm")
 After coercing to a Seurat object all of the metadata is still accessible. 
 
 ```{r coercion to Seurat}
-demoSeurat <- as.Seurat(norm_target_demoData, normData = "q_norm")
+demoSeurat <- as.Seurat(x = norm_target_demoData, normData = "q_norm")
 
 demoSeurat # overall data object
 


### PR DESCRIPTION
quick bug fixes:
- version numbers are more stringent with classes in R 4.4  (5 != 5.0.0). This affected both Seurat package version in coercion switch and PKC version checking
- SpatialExperiment plotting in coercion vignette was not equal to the Seurat plotting. Updated the vignette rather than update the coercion. The coordinates were equal between the two objects, just the plotting was different. I think the Seurat plotting function might have been updated so we needed to update to match. 
![image](https://github.com/Nanostring-Biostats/GeomxTools/assets/40255151/4400c24f-6a4a-4d20-a9a5-086bbd36703c)

![image](https://github.com/Nanostring-Biostats/GeomxTools/assets/40255151/92e3eb47-187c-4a58-98f3-94e14b199faf)


Version issue is a [package building blocker on bioc](https://bioconductor.org/checkResults/devel/bioc-LATEST/GeomxTools/nebbiolo1-buildsrc.html) since one test fails and the coercion vignette can't knit.  

[R CMD check](https://github.com/Nanostring-Biostats/GeomxTools/files/14715505/00check.log) passed with 5 expected warnings.

[R 4.4 install](https://cran.r-project.org/bin/windows/base/rdevel.html) I don't think this update is necessary but it might be. 