### PR TITLE
Update coercions.R

### DIFF
--- a/R/coercions.R
+++ b/R/coercions.R
@@ -308,7 +308,7 @@ as.SpatialExperiment.NanoStringGeoMxSet <- function(x, normData = NULL,
                                                 rowData = fData(x),
                                                 spatialCoords = coord.df)
     
-    names(spe@assays@data) <- "GeoMx"
+    names(spe@assays@data) <- "geomx"
     
     spe@metadata <- otherInfo(experimentData(x))
     spe@metadata[["sequencingMetrics"]] <- sData(x)[colnames(sData(x)) %in% 


### PR DESCRIPTION
Corrected issue where getter/setter functions for GeoMx assays in the generated SpatialExperiment object don't work. SpatialExperiment assay names must be in lower case for this functionality