### PR TITLE
add functionality for passing a data.frame directly into readNanoStringGeoMxSet

### DIFF
--- a/R/readNanoStringGeoMxSet.R
+++ b/R/readNanoStringGeoMxSet.R
@@ -1,8 +1,9 @@
 readNanoStringGeoMxSet <-
 function(dccFiles,
          pkcFiles,
-         phenoDataFile,
-         phenoDataSheet,
+         phenoData=NULL,
+         phenoDataFile=NULL,
+         phenoDataSheet=NULL,
          phenoDataDccColName = "Sample_ID",
          phenoDataColPrefix = "",
          protocolDataColNames = NULL,
@@ -28,10 +29,18 @@ function(dccFiles,
               names = rownames(x[["Code_Summary"]])))
   
   # Create phenoData
-  if (is.null(phenoDataFile)) {
-    stop("Please specify an input for phenoDataFile.")
+  if (is.null(phenoDataFile) && is.null(phenoData)) {
+      stop("Please specify a value for phenoData or phenoDataFile.")
   } else {
-    pheno <- readxl::read_xlsx(phenoDataFile, col_names = TRUE, sheet = phenoDataSheet, ...)
+    if (!is.null(phenoDataFile) && !is.null(phenoData)) {
+      stop("Please specify a value for phenoData or phenoDataFile, but not both.")
+    } else {
+      if (!is.null(phenoDataFile)) {
+        pheno <- readxl::read_xlsx(phenoDataFile, col_names = TRUE, sheet = phenoDataSheet, ...)
+      } else { # Means that phenoData must be not NULL
+        pheno = phenoData
+      }
+    }
     pheno <- data.frame(pheno, stringsAsFactors = FALSE, check.names = FALSE)
     j <- colnames(pheno)[colnames(pheno) == phenoDataDccColName]
     if (length(j) == 0L){


### PR DESCRIPTION
Currently the `readNanoStringGeoMxSet` function requires that a path to a phenoData Excel file be provided. This is inflexible to workflows that generate phenoData files programmatically as writing out Excel files with R, python, etc. is unnecessary and can be imperfect. Excel files are also inconvenient to interact with on headless machines where Geomx_Tools analysis tools are likely being conducted.

This PR adds the `phenoData` argument to `readNanoStringGeoMxSet` and asserts that it is passed mutually exclusively with `phenoDataFile`. If `phenoData` is passed, it is assigned directly to the `pheno` variable, circumventing `readxl::read_xlsx`. Anything that can be coerced to a `data.frame` should work.

There is a probably a cleaner way to do this, and I would be happy to do that clean up if there is interest in merging this PR.