### PR TITLE
remove groupVar from rownames(lsm) carefully

### DIFF
--- a/R/NanoStringGeoMxSet-de.R
+++ b/R/NanoStringGeoMxSet-de.R
@@ -70,7 +70,8 @@ mixedModelDE <- function(object, elt = "exprs", modelFormula = NULL,
         lsm <- lmerTest::ls_means(lmOut, which = groupVar, pairwise = TRUE)
       }
       lmOut <- matrix(stats::anova(lmOut)[groupVar, "Pr(>F)"], ncol = 1, dimnames = list(groupVar, "Pr(>F)"))
-      lsmOut <- matrix(cbind(lsm[,"Estimate"], lsm[,"Pr(>|t|)"]), ncol = 2, dimnames = list(gsub(groupVar, "", rownames(lsm)), c("Estimate", "Pr(>|t|)")))
+      row_name <- gsub(paste0(" ", groupVar), " ", gsub(paste0("^", groupVar), "", rownames(lsm)))
+      lsmOut <- matrix(cbind(lsm[,"Estimate"], lsm[,"Pr(>|t|)"]), ncol = 2, dimnames = list(row_name, c("Estimate", "Pr(>|t|)")))
 
       return(list(anova = lmOut, lsmeans = lsmOut))
     }
@@ -99,7 +100,8 @@ mixedModelDE <- function(object, elt = "exprs", modelFormula = NULL,
         lsm <- lmerTest::ls_means(lmOut, which = groupVar, pairwise = TRUE)
       }
       lmOut <- matrix(stats::anova(lmOut)[groupVar, "Pr(>F)"], ncol = 1, dimnames = list(groupVar, "Pr(>F)"))
-      lsmOut <- matrix(cbind(lsm[,"Estimate"], lsm[,"Pr(>|t|)"]), ncol = 2, dimnames = list(gsub(groupVar, "", rownames(lsm)), c("Estimate", "Pr(>|t|)")))
+      row_name <- gsub(paste0(" ", groupVar), " ", gsub(paste0("^", groupVar), "", rownames(lsm)))
+      lsmOut <- matrix(cbind(lsm[,"Estimate"], lsm[,"Pr(>|t|)"]), ncol = 2, dimnames = list(row_name, c("Estimate", "Pr(>|t|)")))
 
       return(list(anova = lmOut, lsmeans = lsmOut))
     }


### PR DESCRIPTION
groupVar string was removed from a contrast string using 'gsub' command with surprising outcomes in a few cases. For example, 'MUTATIONMUTATION - MUTATIONnormal' would be modified to ' - normal'. Seeing this in the results, the user could wonder if the correct set of samples had been used in the comparison. By limiting this gsub operation and performing it twice, we avoid this cosmetic problem.