### PR TITLE
Log protein

### DIFF
--- a/R/NanoStringGeoMxSet-autoplot.R
+++ b/R/NanoStringGeoMxSet-autoplot.R
@@ -100,16 +100,20 @@ qcProteinSignal <- function(object, neg.names=NULL) {
         neg.names <- iggNames(object)
     }
     
-    snr <- snrOrder(object, neg.names)
+    snr <- GeomxTools:::snrOrder(object, neg.names)
     
     protnames <- rownames(snr)
-    ylim <- range(log2(snr))
+    
+    nonZero <- snr
+    nonZero[nonZero == 0] <- NA
+    ylim <- log2(range(nonZero, na.rm = TRUE))
     if(ylim[1L] == -Inf){
       ylim[1L] <- 0
     }
     if(ylim[2L] == -Inf){
       ylim[2L] <- 0
     }
+    rm(nonZero)
     
     fig <- function(){
         par(mar = c(11, 4, 2, 1))

--- a/R/NanoStringGeoMxSet-autoplot.R
+++ b/R/NanoStringGeoMxSet-autoplot.R
@@ -100,31 +100,25 @@ qcProteinSignal <- function(object, neg.names=NULL) {
         neg.names <- iggNames(object)
     }
     
-    snr <- GeomxTools:::snrOrder(object, neg.names)
+    snr <- snrOrder(object, neg.names)
     
     protnames <- rownames(snr)
     
     nonZero <- snr
     nonZero[nonZero == 0] <- NA
     ylim <- log2(range(nonZero, na.rm = TRUE))
-    if(ylim[1L] == -Inf){
-      ylim[1L] <- 0
-    }
-    if(ylim[2L] == -Inf){
-      ylim[2L] <- 0
-    }
     rm(nonZero)
     
     fig <- function(){
         par(mar = c(11, 4, 2, 1))
-        boxplot(t(log2(snr)),
+        suppressWarnings(boxplot(t(log2(snr)),
                 las = 2,
                 outline = FALSE,
                 ylim = ylim,
                 names = protnames,
                 ylab = "Log2 signal-to-background ratio",
                 cex.axis = .85 - 0.3 * (nrow(snr) > 60)
-        )
+        ))
         axis(2, at = 1, labels = 1, las = 2, cex = 0.5)
         points(jitter(rep(1:nrow(snr), ncol(snr))),
                log2(snr),

--- a/tests/testthat/test_protein.R
+++ b/tests/testthat/test_protein.R
@@ -113,9 +113,9 @@ test_that("Correct segment flags are added to protein data",{
 
 # Spec 21: A warning is given if protein data is run through setBioProbeQCFlags.:------
 test_that("Warnings are given if protein data is run through setBioProbeQCFlags", {
-  expect_warning(expect_warning(expect_warning(expect_warning(
-    setBioProbeQCFlags(proteinData, qcCutoffs=list(minProbeRatio=0.1,
-                                                   percentFailGrubbs=20))))))
+  expect_warning(setBioProbeQCFlags(proteinData, 
+                                    qcCutoffs=list(minProbeRatio=0.1,
+                                                   percentFailGrubbs=20)))
 })
 
 
@@ -221,7 +221,10 @@ test_that("QC plots are plotted", {
   expect_true(all(proteinOrder %in% rownames(proteinData)))
   expect_true(all(rownames(proteinData) %in% proteinOrder))
   
-  expect_error(qcProteinSignal(object = RNAData))
+  exprs(proteinData)[igg.names[1],] <- 0
+  fig <- qcProteinSignal(object = proteinData,
+                         neg.names = igg.names)
+  expect_true(par("usr")[3L] < -1) # confirm 0s don't cutoff negative part of graph
 })
 
 


### PR DESCRIPTION
log2(0) == -Inf which causes issues when trying to set the ylimit for boxplots. GeomxTools set -Inf to 0 which cuts off the negative parts of the plot. This PR allows does not allow 0s to affect the limit setting of the plot. 
[GxTProteinPlotting.pdf](https://github.com/user-attachments/files/19948840/GxTProteinPlotting.pdf)

Issue 220841

devtools::check()
![image](https://github.com/user-attachments/assets/711633cc-f04c-4bb8-998b-2e882a6be3f6)
