### PR TITLE
remove ggiraph dependency

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -5,7 +5,7 @@ Description: Tools for NanoString Technologies GeoMx Technology.  Package provid
 Version: 3.12.1
 Encoding: UTF-8
 Authors@R: c(person("Maddy", "Griswold", email = "mgriswold@nanostring.com", role = c("cre", "aut")),
-	     person("Nicole", "Ortogero", email = "nortogero@nanostring.com", role = c("aut")), 
+             person("Nicole", "Ortogero", email = "nortogero@nanostring.com", role = c("aut")), 
              person("Zhi", "Yang", role = c("aut")),
              person("Ronalyn", "Vitancol", email = "rvitancol@nanostring.com", role = c("aut")),
              person("David", "Henderson", role = c("aut")))
@@ -18,7 +18,6 @@ Suggests:
     knitr,
     testthat (>= 3.0.0),
     parallel,
-    ggiraph,
     Seurat,
     SpatialExperiment (>= 1.4.0),
     SpatialDecon,

--- a/tests/testthat/test_QC.R
+++ b/tests/testthat/test_QC.R
@@ -4,7 +4,6 @@ library(NanoStringNCTools)
 library(GeomxTools)
 library(testthat)
 library(EnvStats)
-library(ggiraph)
 
 
 testDataRaw <- readRDS(file= system.file("extdata","DSP_NGS_Example_Data", 
@@ -174,7 +173,7 @@ test_results <- readRDS("testData/outliersGrubbsTest.RDS")
 test_results <- test_results[names(test_results) %in% colnames(testDataRaw)]
 
 test_that("copied grubbs test function works as expected",{
-    expect_equal(test_results, apply(neg_set, 2, grubbs.test, two.sided=TRUE),
+    expect_equal(test_results, apply(neg_set, 2, GeomxTools:::grubbs.test, two.sided=TRUE),
                  tolerance = 1e-12)
 })
 

--- a/vignettes/Developer_Introduction_to_the_NanoStringGeoMxSet.Rmd
+++ b/vignettes/Developer_Introduction_to_the_NanoStringGeoMxSet.Rmd
@@ -37,7 +37,6 @@ Loading the NanoStringNCTools and GeoMxTools packages allow users access to the 
 library(NanoStringNCTools)
 library(GeomxTools)
 library(EnvStats)
-library(ggiraph)
 ```
 
 ## Building a NanoStringGeoMxSet from .DCC files 


### PR DESCRIPTION
Remove unused ggiraph dependency #217 

<img width="373" height="52" alt="image" src="https://github.com/user-attachments/assets/d99d1fed-b670-48db-b307-07c32ae0e43b" />
